### PR TITLE
ComponentThread: add missing include of <functional>

### DIFF
--- a/src/internal/ComponentThread.h
+++ b/src/internal/ComponentThread.h
@@ -28,6 +28,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 
 #include <condition_variable>
 #include <thread>
+#include <functional>
 
 namespace DSPatch
 {


### PR DESCRIPTION
Without this include, the project would not compile using GCC 8.2.1 on Archlinux.